### PR TITLE
CP-556(fix): Ensure art-title class is applied to art cards in chicago art search

### DIFF
--- a/src/components/ChicagoArt/ArtCard.tsx
+++ b/src/components/ChicagoArt/ArtCard.tsx
@@ -16,7 +16,10 @@ const ArtCard = ({
         alt={thumbnail?.alt_text || title}
       />
       <div className={styles['art-overlay']}>
-        <div className="art-title" data-testid={`art-listing-title-${imageId}`}>
+        <div
+          className={styles['art-title']}
+          data-testid={`art-listing-title-${imageId}`}
+        >
           {title}
         </div>
         {artistTitle ? (


### PR DESCRIPTION
<img width="660" alt="image" src="https://github.com/CalCorbin/cal-portfolio/assets/8878117/4eb12888-6fba-40ae-8c67-89c16455371c">
