### PR TITLE
bug: fix github url for chicago art page

### DIFF
--- a/src/components/ChicagoArt/ChicagoArt.tsx
+++ b/src/components/ChicagoArt/ChicagoArt.tsx
@@ -52,7 +52,7 @@ const ChicagoArt = () => {
         <div className={styles['header-overlay']} />
         <div className={styles['search-container']}>
           <Header
-            repoLink="https://github.com/CalCorbin/cal-portfolio/blob/master/src/pages/ChicagoArt/ChicagoArt.tsx"
+            repoLink="https://github.com/CalCorbin/cal-portfolio/blob/master/src/components/ChicagoArt/ChicagoArt.tsx"
             title="Art Search"
             useDarkMode
           />


### PR DESCRIPTION
**Description**

This PR fixes an outdated URL on the chicago art page.

**Checklist**

* [x] `eslint` and `prettier` have been run
* [ ] Tests are included if applicable