### PR TITLE
chore: Remove prop-types library and related code

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "graphql": "16.8.1",
     "next": "^14.1.3",
     "node-fetch": "2.6.6",
-    "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-query": "^3.39.3",

--- a/src/components/Ship/Ship.tsx
+++ b/src/components/Ship/Ship.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { IShip, Mission } from './ShipInterface';
 import styles from './Ship.module.css';
 
@@ -91,24 +90,6 @@ const Ship = ({ ship }: IShip) => {
 
 Ship.defaultProps = {
   ship: null,
-};
-
-Ship.propTypes = {
-  ship: PropTypes.shape({
-    id: PropTypes.string,
-    name: PropTypes.string,
-    home_port: PropTypes.string,
-    active: PropTypes.bool,
-    image: PropTypes.string,
-    url: PropTypes.string,
-    weight_lbs: PropTypes.number,
-    missions: PropTypes.arrayOf(
-      PropTypes.shape({
-        flight: PropTypes.string,
-        name: PropTypes.string,
-      })
-    ),
-  }),
 };
 
 export default Ship;


### PR DESCRIPTION
**Description**

Now that the client uses Typescript, prop-types are no longer needed. This PR removes prop-types and related code.

**Screen captures**

_If applicable, include screen captures of expected & actual behavior._

**Checklist**

* [x] `eslint` and `prettier` have been run
* [ ] Tests are included if applicable