### PR TITLE
chore: Get firebase preview URL in gh actions

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,21 +2,36 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+
+on: pull_request
+
 jobs:
   build_and_preview:
-    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - run: |
-          npm i
-          npm run test:ci -- --no-experimental-fetch
-          npm run build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run tests
+        run: npm run test:ci -- --no-experimental-fetch
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to Firebase Hosting
+        id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAL_PORTFOLIO_C40AA }}'
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CAL_PORTFOLIO_C40AA }}
           projectId: cal-portfolio-c40aa
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
+
+      - name: Echo the URL
+        run: echo '🚀[Preview URL](${{ steps.deploy.outputs.details_url }})'


### PR DESCRIPTION
**Description**

In order to run basic e2e tests before deploy, we need access to the firebase preview URL in gh actions. This PR updates the pull request yml file to handle that.

**Screen captures**

_If applicable, include screen captures of expected & actual behavior._

**Checklist**

* [ ] `eslint` and `prettier` have been run
* [ ] Tests are included if applicable