### PR TITLE
feat: Add furbot project to landing page

### DIFF
--- a/cypress/e2e/furbot.cy.js
+++ b/cypress/e2e/furbot.cy.js
@@ -1,0 +1,18 @@
+describe('Furbot e2e tests', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the furbot project and view the github code example', () => {
+    // Open the furbot project
+    cy.contains('a', 'Furbot: The Discord Bot')
+      .invoke('removeAttr', 'target')
+      .click();
+
+    // Verify the github readme page loads for furbot
+    cy.origin('https://github.com', () => {
+      cy.get('div[id="repository-container-header"]').should('be.visible');
+      cy.contains('a', 'furbot').should('be.visible');
+    });
+  });
+});

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -23,18 +23,18 @@ const PROJECTS: Array<Project> = [
     img: 'https://images.unsplash.com/flagged/photo-1572392640988-ba48d1a74457?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8NHx8YXJ0fGVufDB8fDB8fA%3D%3D&auto=format&fit=crop&w=900&q=60',
     hasBackButton: false,
   },
-  // The Fanwave website is dead :(
-  // {
-  //   id: 7,
-  //   title: 'Fanwave',
-  //   link: 'https://okc.fanwave.io/',
-  //   img: 'https://uploads-ssl.webflow.com/618cc38d18a62f370fa48fb4/6190616f493d272fbae5cba9_fanwave%20svg.svg',
-  // },
   {
     id: 6,
     title: 'HexClock',
     link: ROUTES.HEXCLOCK,
     img: 'https://images.unsplash.com/photo-1550534791-2677533605ab',
+    hasBackButton: false,
+  },
+  {
+    id: 7,
+    title: 'Furbot: The Discord Bot',
+    link: 'https://github.com/CalCorbin/furbot',
+    img: 'https://images.pexels.com/photos/5418837/pexels-photo-5418837.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
     hasBackButton: false,
   },
   {
@@ -44,6 +44,7 @@ const PROJECTS: Array<Project> = [
     img: 'https://images.unsplash.com/photo-1549545931-59bf067af9ab',
     hasBackButton: false,
   },
+
   {
     id: 9,
     title: 'Tic Tac Toe',


### PR DESCRIPTION
**Description**

This PR adds my Discord bot called Furbot to the project homepage. The project links to the code to set up the furbot.

Changes include:
1. Link to Furbot code in Github.
2. e2e test.

**Screen captures**
1. Homepage after adding the furbot.
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/3600e679-bcbf-4746-976c-b17bed29b505">

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable