### PR TITLE
chore: Add cypress e2e tests for all projects

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,7 @@ This repo hosts the code for my personal developer site. This is always a consta
 - [Install locally](#setting-up-local-environment)
 - [Pull Request](#pull-requests)
 - [Testing](#testing)
+- [End to End Testing on Pull Requests](#end-to-end-testing-on-pull-requests)
 - [Updating Firebase CI](#updating-firebase-ci)
 
 ## Setting up local environment
@@ -27,6 +28,19 @@ Do the following before creating a pull request.
 
 1. To run all the tests for react components, run `npm run test`
 2. To run tests on a specific component, run `npm run test componentName`
+3. To run e2e tests, run `npm run test:e2e`. Local server must be running. [See below](#end-to-end-testing-on-pull-requests) for more information.
+
+## End to End Testing on Pull Requests
+- To test locally, run `npm run test:e2e`. These will run on your running local server.
+- These are true end to end tests, they should cover a very basic user path.
+    - If you think a test belongs in a component or unit test, then it probably does. These e2e should be used sparingly.
+- Each pull request will trigger an end to end test on the PR. This test will run on the PR's preview URL.
+- The test will check to ensure all pages are loading correctly.
+- These are ephemeral environments generated in Firebase and will be deleted after the PR is closed.
+- If the test fails:
+    - Check the logs in the PR to see what failed.
+    - If the test failed due to a bug in the code, fix the bug and push the changes to the PR.
+    - Github might be down. These are true e2e tests and rely on Github to be up and running.
 
 ## Updating Firebase CI
 

--- a/cypress/e2e/cactiCorral.cy.js
+++ b/cypress/e2e/cactiCorral.cy.js
@@ -1,0 +1,13 @@
+describe('Cacti Corral', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the Cacti Corral page and view a github code sample', () => {
+    // Open the Cacti Corral page
+    cy.contains('a', 'Cacti Corral').invoke('removeAttr', 'target').click();
+
+    // Verify the Cacti Corral github code example loads
+    cy.assertGithubReadmeLoaded('cacti-corral');
+  });
+});

--- a/cypress/e2e/catChat.cy.js
+++ b/cypress/e2e/catChat.cy.js
@@ -1,0 +1,17 @@
+describe('Cat Chat', () => {
+  beforeEach(() => cy.visit('/'));
+
+  it('should open the Cat Chat project and view the github code example', () => {
+    // Click on the Cat Chat project
+    cy.contains('a', 'Cat Chat').invoke('removeAttr', 'target').click();
+
+    // Verify the Cat Chat project loads and open the github code example
+    cy.contains('h1', 'Cat Chat').should('be.visible');
+    cy.findByRole('link', {
+      name: 'View the code for Cat Chat on GitHub',
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/e2e/chicagoArt.cy.js
+++ b/cypress/e2e/chicagoArt.cy.js
@@ -1,0 +1,21 @@
+describe('Chicago Art', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the Chicago Art page and view a github code sample', () => {
+    // Open the Chicago Art page
+    cy.contains('a', 'Art Institute of Chicago Search')
+      .invoke('removeAttr', 'target')
+      .click();
+
+    // Verify the Chicago Art page loads and open the github code example
+    cy.contains('h1', 'Art Search').should('be.visible');
+    cy.findByRole('link', {
+      name: 'View the code for Art Search on GitHub',
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/e2e/furbot.cy.js
+++ b/cypress/e2e/furbot.cy.js
@@ -1,4 +1,4 @@
-describe('Furbot e2e tests', () => {
+describe('Furbot', () => {
   beforeEach(() => {
     cy.visit('/');
   });
@@ -10,9 +10,6 @@ describe('Furbot e2e tests', () => {
       .click();
 
     // Verify the github readme page loads for furbot
-    cy.origin('https://github.com', () => {
-      cy.get('div[id="repository-container-header"]').should('be.visible');
-      cy.contains('a', 'furbot').should('be.visible');
-    });
+    cy.assertGithubReadmeLoaded('furbot');
   });
 });

--- a/cypress/e2e/hexClock.cy.js
+++ b/cypress/e2e/hexClock.cy.js
@@ -1,0 +1,17 @@
+describe('HexClock', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should visit the HexClock project and view the github code example', () => {
+    // Open the HexClock project
+    cy.contains('a', 'HexClock').invoke('removeAttr', 'target').click();
+
+    // Verify the HexClock page loads and open the github code example
+    cy.contains('h1', 'HexClock').should('be.visible');
+    cy.findByRole('link', { name: 'View the code for HexClock on GitHub' })
+      .invoke('removeAttr', 'target')
+      .click();
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/e2e/minesweeper.cy.js
+++ b/cypress/e2e/minesweeper.cy.js
@@ -1,4 +1,4 @@
-describe('Minesweeper e2e tests', () => {
+describe('Minesweeper', () => {
   beforeEach(() => {
     cy.visit('/');
   });
@@ -12,10 +12,6 @@ describe('Minesweeper e2e tests', () => {
     cy.findByRole('link', { name: 'View the code for Mine Sweeper on GitHub' })
       .invoke('removeAttr', 'target')
       .click();
-
-    // Verify the github code example page loads
-    cy.origin('https://github.com', () => {
-      cy.get('div[data-testid="blob-size"]').should('be.visible');
-    });
+    cy.assertGithubCodeExampleLoaded();
   });
 });

--- a/cypress/e2e/spaceX.cy.js
+++ b/cypress/e2e/spaceX.cy.js
@@ -1,0 +1,19 @@
+describe('SpaceX', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the SpaceX page and view a github code sample', () => {
+    // Open the SpaceX page
+    cy.contains('a', 'SpaceX GraphQL').invoke('removeAttr', 'target').click();
+
+    // Verify the SpaceX page loads and open the github code example
+    cy.contains('h1', 'SpaceX Marine Transport Ships').should('be.visible');
+    cy.findByRole('link', {
+      name: 'View the code for SpaceX Marine Transport Ships on GitHub',
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/e2e/starTrekElevator.cy.js
+++ b/cypress/e2e/starTrekElevator.cy.js
@@ -1,0 +1,15 @@
+describe('Star Trek Elevator', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the Star Trek Elevator page and view a github code sample', () => {
+    // Open the Star Trek Elevator page
+    cy.contains('a', 'Star Trek Elevator')
+      .invoke('removeAttr', 'target')
+      .click();
+
+    // Verify the Star Trek Elevator github code example loads
+    cy.assertGithubReadmeLoaded('elevatorGame');
+  });
+});

--- a/cypress/e2e/testDrivenDevelopment.cy.js
+++ b/cypress/e2e/testDrivenDevelopment.cy.js
@@ -1,0 +1,15 @@
+describe('Test Driven Development', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should open the Test Driven Development page and view a github code sample', () => {
+    // Open the Test Driven Development page
+    cy.contains('a', 'Test Driven Development')
+      .invoke('removeAttr', 'target')
+      .click();
+
+    // Verify the Test Driven Development github code example loads
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/e2e/ticTacToe.cy.js
+++ b/cypress/e2e/ticTacToe.cy.js
@@ -1,0 +1,20 @@
+describe('Tic Tac Toe', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.viewport('macbook-15');
+  });
+
+  it('should open the Tic Tac Toe page and view a github code sample', () => {
+    // Open the Tic Tac Toe page
+    cy.contains('a', 'Tic Tac Toe').invoke('removeAttr', 'target').click();
+
+    // Verify the Tic Tac Toe page loads and open the github code example
+    cy.contains('h1', 'Tic Tac Toe').should('be.visible');
+    cy.findByRole('link', {
+      name: 'View the code for Tic Tac Toe on GitHub',
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+    cy.assertGithubCodeExampleLoaded();
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -2,3 +2,18 @@
 /// <reference types="cypress" />
 
 import '@testing-library/cypress/add-commands';
+
+// Custom command for asserting Github code example loaded
+Cypress.Commands.add('assertGithubCodeExampleLoaded', () => {
+  cy.origin('https://github.com', () => {
+    cy.get('div[data-testid="blob-size"]').should('be.visible');
+  });
+});
+
+// Custom command for asserting Github README loaded
+Cypress.Commands.add('assertGithubReadmeLoaded', (title: string) => {
+  cy.origin('https://github.com', { args: { title } }, ({ title }) => {
+    cy.get('div[id="repository-container-header"]').should('be.visible');
+    cy.contains('a', title).should('be.visible');
+  });
+});


### PR DESCRIPTION
**Description**

This PR creates e2e tests in cypress for all projects listed on https://calcorbin.com. Additionally, documentation in the README has been updated to reflect this.

**Screen captures**

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/e6719ca2-f80a-4265-ab3e-1028c3557046">

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable