### PR TITLE
feat: Add backbutton to minesweeper page

### DIFF
--- a/cypress/e2e/minesweeper.cy.js
+++ b/cypress/e2e/minesweeper.cy.js
@@ -5,7 +5,7 @@ describe('Minesweeper', () => {
 
   it('should open the minesweeper project and view the github code example', () => {
     // Open the minesweeper project
-    cy.contains('a', 'MineSweeper').invoke('removeAttr', 'target').click();
+    cy.contains('a', 'MineSweeper').click();
 
     // Verify minesweeper page loads and open the github code example
     cy.contains('h1', 'Mine Sweeper').should('be.visible');
@@ -13,5 +13,19 @@ describe('Minesweeper', () => {
       .invoke('removeAttr', 'target')
       .click();
     cy.assertGithubCodeExampleLoaded();
+  });
+
+  it('should open the minesweeper project, then go back to the home page', () => {
+    // Open the minesweeper project
+    cy.contains('a', 'MineSweeper').click();
+
+    // Verify minesweeper page loads and go back to the home page
+    cy.contains('h1', 'Mine Sweeper').should('be.visible');
+
+    // Go back to the home page
+    cy.contains('button', 'Back').click();
+
+    // Verify home page loads
+    cy.contains('div', 'cal corbin').should('be.visible');
   });
 });

--- a/src/components/BackButton/BackButton.module.css
+++ b/src/components/BackButton/BackButton.module.css
@@ -1,0 +1,22 @@
+.backButton {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin-left: 1rem;
+    margin-top: 0.5rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    color: white;
+    background-color: #333;
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    transition: background-color 0.3s, box-shadow 0.3s;
+    font-size: 1rem;
+    letter-spacing: 0.05rem;
+}
+
+.backButton:hover {
+    background-color: #555;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}

--- a/src/components/BackButton/BackButton.test.tsx
+++ b/src/components/BackButton/BackButton.test.tsx
@@ -1,11 +1,14 @@
+import { render, fireEvent, screen } from '@testing-library/react';
 import BackButton from './BackButton';
-import { render, fireEvent } from '@testing-library/react';
 
 describe('<BackButton />', () => {
+  const prepareComponent = () => render(<BackButton />);
+
   it('should fire window.history.back() when clicked', () => {
     const spy = jest.spyOn(window.history, 'back');
-    const { getByTestId } = render(<BackButton />);
-    fireEvent.click(getByTestId('back-button'));
+    prepareComponent();
+
+    fireEvent.click(screen.getByLabelText('Go back'));
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/components/BackButton/BackButton.tsx
+++ b/src/components/BackButton/BackButton.tsx
@@ -1,6 +1,19 @@
+import React from 'react';
+import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styles from './BackButton.module.css';
+
 const BackButton = () => {
   return (
-    <button data-testid="back-button" onClick={() => window.history.back()}>
+    <button
+      className={styles.backButton}
+      onClick={() => window.history.back()}
+      aria-label="Go back"
+    >
+      <FontAwesomeIcon
+        icon={faChevronLeft}
+        style={{ color: 'white', paddingRight: '0.5rem' }}
+      />
       Back
     </button>
   );

--- a/src/components/MineSweeper/MineSweeper.test.tsx
+++ b/src/components/MineSweeper/MineSweeper.test.tsx
@@ -1,10 +1,13 @@
-import { render } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MineSweeper from './MineSweeper';
 
 describe('MineSweeper', () => {
-  it('should render successfully', () => {
-    const { getByTestId } = render(<MineSweeper />);
-    expect(getByTestId('mine-sweeper')).toBeInTheDocument();
+  const prepareComponent = () => render(<MineSweeper />);
+  afterEach(cleanup);
+
+  it('should render back button', () => {
+    prepareComponent();
+    expect(screen.getByLabelText('Go back')).toBeInTheDocument();
   });
 });

--- a/src/components/MineSweeper/MineSweeper.tsx
+++ b/src/components/MineSweeper/MineSweeper.tsx
@@ -1,9 +1,11 @@
 import Board from './Board';
 import Header from '../Header/Header';
 import styles from './MineSweeper.module.css';
+import BackButton from '../BackButton/BackButton';
 
 const MineSweeper = () => (
   <div className={styles['mine-sweeper']} data-testid="mine-sweeper">
+    <BackButton />
     <div className={styles['mine-sweeper-container']}>
       <Header
         useDarkMode

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -14,7 +14,7 @@ const PROJECTS: Array<Project> = [
     title: 'MineSweeper',
     link: ROUTES.MINESWEEPER,
     img: 'https://images.pexels.com/photos/4811240/pexels-photo-4811240.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-    hasBackButton: false,
+    hasBackButton: true,
   },
   {
     id: 8,


### PR DESCRIPTION
**Description**

This PR adds a back button to the Minesweeper page. This button will take the user back to my landing page.

**Screen captures**

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/4be8cde4-bdab-437b-8973-a17f083819d8">

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable