### PR TITLE
Add retries to cypress tests with external links

### DIFF
--- a/cypress/e2e/cactiCorral.cy.js
+++ b/cypress/e2e/cactiCorral.cy.js
@@ -3,11 +3,19 @@ describe('Cacti Corral', () => {
     cy.visit('/');
   });
 
-  it('should open the Cacti Corral page and view a github code sample', () => {
-    // Open the Cacti Corral page
-    cy.contains('a', 'Cacti Corral').click();
+  it(
+    'should open the Cacti Corral page and view a github code sample',
+    {
+      retries: {
+        runMode: 2,
+      },
+    },
+    () => {
+      // Open the Cacti Corral page
+      cy.contains('a', 'Cacti Corral').click();
 
-    // Verify the Cacti Corral github code example loads
-    cy.assertGithubReadmeLoaded('cacti-corral');
-  });
+      // Verify the Cacti Corral github code example loads
+      cy.assertGithubReadmeLoaded('cacti-corral');
+    }
+  );
 });

--- a/cypress/e2e/furbot.cy.js
+++ b/cypress/e2e/furbot.cy.js
@@ -3,11 +3,19 @@ describe('Furbot', () => {
     cy.visit('/');
   });
 
-  it('should open the furbot project and view the github code example', () => {
-    // Open the furbot project
-    cy.contains('a', 'Furbot: The Discord Bot').click();
+  it(
+    'should open the furbot project and view the github code example',
+    {
+      retries: {
+        runMode: 2,
+      },
+    },
+    () => {
+      // Open the furbot project
+      cy.contains('a', 'Furbot: The Discord Bot').click();
 
-    // Verify the github readme page loads for furbot
-    cy.assertGithubReadmeLoaded('furbot');
-  });
+      // Verify the github readme page loads for furbot
+      cy.assertGithubReadmeLoaded('furbot');
+    }
+  );
 });

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -1,35 +1,43 @@
-describe('Landing Page', () => {
-  beforeEach(() => {
-    cy.visit('/');
+describe(
+  'Landing Page',
+  {
+    retries: {
+      runMode: 2,
+    },
+  },
+  () => {
+    beforeEach(() => {
+      cy.visit('/');
 
-    // Load the page
-    cy.findByText('cal corbin').should('be.visible');
-  });
+      // Load the page
+      cy.findByText('cal corbin').should('be.visible');
+    });
 
-  it('should go to landing page and open the LinkedIn link', () => {
-    // Click on the LinkedIn link
-    cy.get('a[href="https://www.linkedin.com/in/calcorbin/"]').click();
+    it('should go to landing page and open the LinkedIn link', () => {
+      // Click on the LinkedIn link
+      cy.get('a[href="https://www.linkedin.com/in/calcorbin/"]').click();
 
-    // Verify the LinkedIn link opens
-    cy.origin('https://www.linkedin.com/in/calcorbin/', () => {
-      cy.on('uncaught:exception', (e) => {
-        if (e.message.includes('Things went bad')) {
-          // we expected this error, so let's ignore it
-          // and let the test continue
-          return false;
-        }
+      // Verify the LinkedIn link opens
+      cy.origin('https://www.linkedin.com/in/calcorbin/', () => {
+        cy.on('uncaught:exception', (e) => {
+          if (e.message.includes('Things went bad')) {
+            // we expected this error, so let's ignore it
+            // and let the test continue
+            return false;
+          }
+        });
+        cy.contains('Experience & Education').should('be.visible');
       });
-      cy.contains('Experience & Education').should('be.visible');
     });
-  });
 
-  it('should go to landing page and open the GitHub link', () => {
-    // Click on the GitHub link
-    cy.get('a[href="https://github.com/CalCorbin"]').click();
+    it('should go to landing page and open the GitHub link', () => {
+      // Click on the GitHub link
+      cy.get('a[href="https://github.com/CalCorbin"]').click();
 
-    // Verify the GitHub link opens
-    cy.origin('https://github.com', () => {
-      cy.contains("When I'm not coding").should('be.visible');
+      // Verify the GitHub link opens
+      cy.origin('https://github.com', () => {
+        cy.contains("When I'm not coding").should('be.visible');
+      });
     });
-  });
-});
+  }
+);

--- a/cypress/e2e/spaceX.cy.js
+++ b/cypress/e2e/spaceX.cy.js
@@ -3,17 +3,25 @@ describe('SpaceX', () => {
     cy.visit('/');
   });
 
-  it('should open the SpaceX page and view a github code sample', () => {
-    // Open the SpaceX page
-    cy.contains('a', 'SpaceX GraphQL').click();
+  it(
+    'should open the SpaceX page and view a github code sample',
+    {
+      retries: {
+        runMode: 2,
+      },
+    },
+    () => {
+      // Open the SpaceX page
+      cy.contains('a', 'SpaceX GraphQL').click();
 
-    // Verify the SpaceX page loads and open the github code example
-    cy.contains('h1', 'SpaceX Marine Transport Ships').should('be.visible');
-    cy.findByRole('link', {
-      name: 'View the code for SpaceX Marine Transport Ships on GitHub',
-    })
-      .invoke('removeAttr', 'target')
-      .click();
-    cy.assertGithubCodeExampleLoaded();
-  });
+      // Verify the SpaceX page loads and open the github code example
+      cy.contains('h1', 'SpaceX Marine Transport Ships').should('be.visible');
+      cy.findByRole('link', {
+        name: 'View the code for SpaceX Marine Transport Ships on GitHub',
+      })
+        .invoke('removeAttr', 'target')
+        .click();
+      cy.assertGithubCodeExampleLoaded();
+    }
+  );
 });

--- a/cypress/e2e/starTrekElevator.cy.js
+++ b/cypress/e2e/starTrekElevator.cy.js
@@ -3,11 +3,19 @@ describe('Star Trek Elevator', () => {
     cy.visit('/');
   });
 
-  it('should open the Star Trek Elevator page and view a github code sample', () => {
-    // Open the Star Trek Elevator page
-    cy.contains('a', 'Star Trek Elevator').click();
+  it(
+    'should open the Star Trek Elevator page and view a github code sample',
+    {
+      retries: {
+        runMode: 2,
+      },
+    },
+    () => {
+      // Open the Star Trek Elevator page
+      cy.contains('a', 'Star Trek Elevator').click();
 
-    // Verify the Star Trek Elevator github code example loads
-    cy.assertGithubReadmeLoaded('elevatorGame');
-  });
+      // Verify the Star Trek Elevator github code example loads
+      cy.assertGithubReadmeLoaded('elevatorGame');
+    }
+  );
 });

--- a/cypress/e2e/testDrivenDevelopment.cy.js
+++ b/cypress/e2e/testDrivenDevelopment.cy.js
@@ -3,11 +3,19 @@ describe('Test Driven Development', () => {
     cy.visit('/');
   });
 
-  it('should open the Test Driven Development page and view a github code sample', () => {
-    // Open the Test Driven Development page
-    cy.contains('a', 'Test Driven Development').click();
+  it(
+    'should open the Test Driven Development page and view a github code sample',
+    {
+      retries: {
+        runMode: 2,
+      },
+    },
+    () => {
+      // Open the Test Driven Development page
+      cy.contains('a', 'Test Driven Development').click();
 
-    // Verify the Test Driven Development github code example loads
-    cy.assertGithubCodeExampleLoaded();
-  });
+      // Verify the Test Driven Development github code example loads
+      cy.assertGithubCodeExampleLoaded();
+    }
+  );
 });


### PR DESCRIPTION
**Description**

To make cypress tests more reliable in the CI environment, I've retries to specific e2e tests that test to ensure links to external websites still work. These external links are the biggest source of flakiness in tests, and retries should result in not having to restart workflow files as often.

**Screen captures**

_If applicable, include screen captures of expected & actual behavior._

**Checklist**

* [ ] `eslint` and `prettier` have been run
* [x] Tests are included if applicable