### PR TITLE
Update results grid width and center on page

### DIFF
--- a/src/components/ChicagoArt/SearchResults/SearchResults.module.css
+++ b/src/components/ChicagoArt/SearchResults/SearchResults.module.css
@@ -4,6 +4,8 @@
     justify-content: center;
     align-items: center;
     justify-items: center;
+    width: 70%;
+    margin: 0 auto;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
**Description**

This PR updates the css styling on the SearchResults page. The results are more centered now and have less space between columns.

**Screen captures**

![image](https://github.com/user-attachments/assets/f3141770-87ca-49b8-bacb-3999e087ab62)

**Checklist**

* [ ] `eslint` and `prettier` have been run
* [ ] Tests are included if applicable