### PR TITLE
Fix code coverage issues in useArtworkSearch

### DIFF
--- a/src/hooks/useArtworkSearch.ts
+++ b/src/hooks/useArtworkSearch.ts
@@ -8,8 +8,6 @@ const useArtworkSearch = (query: string, page: number = 1) => {
   return useQuery({
     queryKey: ['artworks', query, page],
     queryFn: async () => {
-      if (!query) return { data: [], pagination: null };
-
       // Do initial search in art collections
       const collections = await fetch(
         `${ARTIC_BASE_PATH}${ARTIC_ARTWORKS}/search`,


### PR DESCRIPTION
**Description**

This PR gets code coverage back to 100% in the useArtworkSearch hook.

**Screen captures**

_If applicable, include screen captures of expected & actual behavior._

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable