### PR TITLE
Clicking an artwork takes you to the artwork page

### DIFF
--- a/src/components/ChicagoArt/ArtCard/ArtCard.module.css
+++ b/src/components/ChicagoArt/ArtCard/ArtCard.module.css
@@ -6,6 +6,11 @@
     border-radius: 3%;
 }
 
+.art a {
+    text-decoration: none;
+    color: inherit;
+}
+
 .art img {
     width: 100%;
     height: 100%;
@@ -33,32 +38,38 @@
 }
 
 .artTitle {
-    font-size: 1rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.95);
+    margin: 1.25rem 1.25rem 0.25rem 1.25rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-weight: bold;
-    text-align: left;
-    color: white;
-    margin: 1rem 1rem 0 1rem;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease;
+    transform-origin: left bottom;
+}
+
+.art:hover .artTitle {
+    transform: translateY(-0.15rem);
 }
 
 .artist {
-    font-size: .8rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: white;
-    margin: 1rem;
-    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 0.25rem 1.25rem 1.25rem 1.25rem;
+    text-decoration: none;
+    opacity: 0;
+    transform: translateY(0.5rem);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
-.artistUnknown {
-    font-size: .8rem;
-    color: white;
-    margin: 1rem;
-    text-decoration: none;
-    cursor: default;
+.art:hover .artist {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .noImageContainer {

--- a/src/components/ChicagoArt/ArtCard/ArtCard.test.tsx
+++ b/src/components/ChicagoArt/ArtCard/ArtCard.test.tsx
@@ -5,6 +5,7 @@ import { ArtProps } from '../types/ChicagoArtInterface';
 
 describe('<ArtCard/>', () => {
   const mockedArt: ArtProps = {
+    id: 21,
     title: 'Library Ladder',
     artist_title: 'William France',
     artist_id: 1,
@@ -19,6 +20,7 @@ describe('<ArtCard/>', () => {
 
   const setup = (props: ArtProps) => {
     const {
+      id,
       title,
       artist_title: artistTitle,
       artist_id: artistId,
@@ -27,6 +29,7 @@ describe('<ArtCard/>', () => {
     } = props;
     render(
       <ArtCard
+        id={id}
         title={title}
         artist_title={artistTitle}
         artist_id={artistId}
@@ -39,6 +42,16 @@ describe('<ArtCard/>', () => {
   it('should render', async () => {
     setup(mockedArt);
     expect(screen.getByTestId('art-listing-1234')).toBeInTheDocument();
+  });
+
+  it('should render link', async () => {
+    setup(mockedArt);
+
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      'https://www.artic.edu/artworks/21/'
+    );
   });
 
   it('should render title', async () => {
@@ -73,27 +86,19 @@ describe('<ArtCard/>', () => {
   });
 
   it('should render unknown artist when artist is not found', async () => {
-    delete mockedArt.artist_title;
-    setup(mockedArt);
+    setup({ ...mockedArt, artist_title: null });
     fireEvent.mouseOver(screen.getByTestId('art-listing-1234'));
     await waitFor(() => {
       screen.getByTestId('art-listing-title-1234');
     });
     expect(screen.getByText(/Artist Unknown/)).toBeInTheDocument();
-    expect(screen.getByTestId('artist-unknown-1234')).toBeInTheDocument();
   });
 
-  it('should render if no thumbnail', async () => {
+  it('should render empty image card if no image is provided', async () => {
     setup({
-      title: 'Library Ladder',
-      artist_title: 'William France',
-      artist_id: 1,
-      thumbnail: {
-        lqip: 'blingblong',
-        width: 400,
-        height: 400,
-        alt_text: 'The ladder inside Full Circle',
-      },
+      ...mockedArt,
+      image_id: null,
+      thumbnail: null,
     });
 
     expect(screen.getByText(/Image Not Available/));
@@ -103,5 +108,38 @@ describe('<ArtCard/>', () => {
     });
     expect(screen.getByText(/Library Ladder/)).toBeInTheDocument();
     expect(screen.getByText(/William France/)).toBeInTheDocument();
+
+    // Assert link exists
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      'https://www.artic.edu/artworks/21/'
+    );
+  });
+
+  it('should render empty image card for unknown artist if no image is provided', async () => {
+    setup({
+      ...mockedArt,
+      image_id: null,
+      thumbnail: null,
+      artist_title: null,
+    });
+
+    expect(screen.getByText(/Image Not Available/));
+    fireEvent.mouseOver(screen.getByTestId('art-listing-no-image'));
+    await waitFor(() => {
+      screen.getByTestId('art-listing-no-image');
+    });
+
+    // Assert artwork and unknown artist
+    expect(screen.getByText(/Artist Unknown/)).toBeInTheDocument();
+    expect(screen.getByText(/Library Ladder/)).toBeInTheDocument();
+
+    // Assert link exists
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      'https://www.artic.edu/artworks/21/'
+    );
   });
 });

--- a/src/components/ChicagoArt/ArtCard/ArtCard.tsx
+++ b/src/components/ChicagoArt/ArtCard/ArtCard.tsx
@@ -1,54 +1,46 @@
+import { memo } from 'react';
 import NoImage from './NoImage';
 import { ArtProps } from '../types/ChicagoArtInterface';
 import styles from './ArtCard.module.css';
 
+const ARTWORK_BASE_URL = 'https://www.artic.edu/artworks';
+const IMAGE_BASE_URL = 'https://www.artic.edu/iiif/2';
+
 const ArtCard = ({
+  id,
   title,
   artist_title: artistTitle,
-  artist_id: artistId,
   image_id: imageId,
   thumbnail,
 }: ArtProps) => {
   if (!imageId)
-    return (
-      <NoImage artistId={artistId} artistTitle={artistTitle} title={title} />
-    );
+    return <NoImage id={id} artistTitle={artistTitle} title={title} />;
 
   return (
     <div className={styles.art} data-testid={`art-listing-${imageId}`}>
-      <img
-        src={`https://www.artic.edu/iiif/2/${imageId}/full/300,/0/default.jpg`}
-        alt={thumbnail?.alt_text || title}
-      />
-      <div className={styles.artOverlay}>
-        <div
-          className={styles.artTitle}
-          data-testid={`art-listing-title-${imageId}`}
-        >
-          {title}
-        </div>
-        {artistTitle ? (
-          <a
-            href={`https://www.artic.edu/artists/${artistId}/`}
+      <a href={`${ARTWORK_BASE_URL}/${id}/`}>
+        <img
+          src={`${IMAGE_BASE_URL}/${imageId}/full/300,/0/default.jpg`}
+          alt={thumbnail?.alt_text || title}
+          loading="lazy"
+        />
+        <div className={styles.artOverlay}>
+          <div
+            className={styles.artTitle}
+            data-testid={`art-listing-title-${imageId}`}
+          >
+            {title}
+          </div>
+          <div
             className={styles.artist}
-            target="_blank"
-            rel="noreferrer"
             data-testid={`art-listing-artist-${imageId}`}
           >
-            {artistTitle}
-          </a>
-        ) : (
-          <div
-            className={styles.artistUnknown}
-            style={{ cursor: 'default' }}
-            data-testid={`artist-unknown-${imageId}`}
-          >
-            Artist Unknown
+            {artistTitle ? artistTitle : 'Artist Unknown'}
           </div>
-        )}
-      </div>
+        </div>
+      </a>
     </div>
   );
 };
 
-export default ArtCard;
+export default memo(ArtCard);

--- a/src/components/ChicagoArt/ArtCard/NoImage.tsx
+++ b/src/components/ChicagoArt/ArtCard/NoImage.tsx
@@ -1,32 +1,31 @@
 import styles from './ArtCard.module.css';
 
 type NoImageProps = {
+  id: number;
   title?: string;
-  artistId?: number;
-  artistTitle?: string;
+  artistTitle?: string | null;
 };
 
-const NoImage = ({ title, artistId, artistTitle }: NoImageProps) => {
+const NoImage = ({ id, title, artistTitle }: NoImageProps) => {
   return (
     <div className={styles.art} data-testid="art-listing-no-image">
-      <div className={styles.noImageContainer}>Image Not Available</div>
-      <div className={styles.artOverlay}>
-        <div
-          className={styles.artTitle}
-          data-testid="art-listing-title-no-image"
-        >
-          {title}
+      <a href={`https://www.artic.edu/artworks/${id}/`}>
+        <div className={styles.noImageContainer}>Image Not Available</div>
+        <div className={styles.artOverlay}>
+          <div
+            className={styles.artTitle}
+            data-testid="art-listing-title-no-image"
+          >
+            {title}
+          </div>
+          <div
+            className={styles.artist}
+            data-testid="art-listing-artist-no-image"
+          >
+            {artistTitle ? artistTitle : 'Artist Unknown'}
+          </div>
         </div>
-        <a
-          href={`https://www.artic.edu/artists/${artistId}/`}
-          className={styles.artist}
-          target="_blank"
-          rel="noreferrer"
-          data-testid="art-listing-artist-no-image"
-        >
-          {artistTitle}
-        </a>
-      </div>
+      </a>
     </div>
   );
 };

--- a/src/components/ChicagoArt/Pagination/Pagination.module.css
+++ b/src/components/ChicagoArt/Pagination/Pagination.module.css
@@ -7,6 +7,12 @@
     flex-wrap: wrap;
 }
 
+@media screen and (max-width: 480px) {
+    .pagination {
+        gap: 0.25rem;
+    }
+}
+
 .ellipsis {
     color: #6b7280;
     padding: 0 0.25rem;

--- a/src/components/ChicagoArt/SearchResults/SearchResults.test.tsx
+++ b/src/components/ChicagoArt/SearchResults/SearchResults.test.tsx
@@ -38,6 +38,7 @@ interface MockedQueryResults {
 
 const mockedArt = [
   {
+    id: 32490432,
     title: 'Library Ladder',
     artist_title: 'William France',
     artist_id: 1,
@@ -50,6 +51,7 @@ const mockedArt = [
     },
   },
   {
+    id: 32490433,
     title:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
     artist_title: 'Chaim Soutine',

--- a/src/components/ChicagoArt/SearchResults/SearchResults.tsx
+++ b/src/components/ChicagoArt/SearchResults/SearchResults.tsx
@@ -32,7 +32,8 @@ const SearchResults = () => {
         ) : art.length ? (
           art.map((item: ArtProps) => (
             <ArtCard
-              key={`${item.artist_id}-${item.title}`}
+              key={item.id}
+              id={item.id}
               title={item.title}
               artist_title={item.artist_title}
               artist_id={item.artist_id}

--- a/src/components/ChicagoArt/types/ChicagoArtInterface.ts
+++ b/src/components/ChicagoArt/types/ChicagoArtInterface.ts
@@ -1,12 +1,13 @@
 export interface ArtProps {
+  id: number;
   title: string;
-  artist_title?: string;
+  artist_title?: string | null;
   artist_id?: number;
-  image_id?: string;
+  image_id?: string | null;
   thumbnail?: {
     lqip?: string;
     width?: number;
     height?: number;
     alt_text?: string;
-  };
+  } | null;
 }

--- a/src/hooks/useArtworkSearch.test.tsx
+++ b/src/hooks/useArtworkSearch.test.tsx
@@ -50,7 +50,7 @@ describe('useArtworkSearch hook', () => {
         // Check that the IDs are correctly included in the URL
         expect(url).toContain('ids=1,2,3,4,5,6,7,8,9,10,11,12');
         expect(url).toContain(
-          'fields=title,image_id,artist_title,thumbnail,artist_id'
+          'fields=id,title,image_id,artist_title,thumbnail,artist_id'
         );
 
         return Promise.resolve({
@@ -100,7 +100,7 @@ describe('useArtworkSearch hook', () => {
     // Assert second call to retrieve metadata about artworks
     const secondCallArgs = (fetch as jest.Mock).mock.calls[1];
     expect(secondCallArgs[0]).toBe(
-      `${ARTIC_BASE_PATH}${ARTIC_ARTWORKS}?ids=1,2,3,4,5,6,7,8,9,10,11,12&fields=title,image_id,artist_title,thumbnail,artist_id`
+      `${ARTIC_BASE_PATH}${ARTIC_ARTWORKS}?ids=1,2,3,4,5,6,7,8,9,10,11,12&fields=id,title,image_id,artist_title,thumbnail,artist_id`
     );
   });
 

--- a/src/hooks/useArtworkSearch.ts
+++ b/src/hooks/useArtworkSearch.ts
@@ -34,7 +34,7 @@ const useArtworkSearch = (query: string, page: number = 1) => {
         .map((item: { id: number }) => item.id)
         .join(',');
       const artworks = await fetch(
-        `${ARTIC_BASE_PATH}${ARTIC_ARTWORKS}?ids=${ids}&fields=title,image_id,artist_title,thumbnail,artist_id`
+        `${ARTIC_BASE_PATH}${ARTIC_ARTWORKS}?ids=${ids}&fields=id,title,image_id,artist_title,thumbnail,artist_id`
       );
       const { data } = await artworks.json();
 


### PR DESCRIPTION
**Description**

This PR makes the UX of artwork results a little more intuitive. When a user clicks an artwork, they are taken to a page with information about the work they have clicked.

**Screen captures**

![image](https://github.com/user-attachments/assets/e85c4885-408b-47c8-ba93-b4d32d8678e1)

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable