### PR TITLE
Chicago Art Bug Fixes

### DIFF
--- a/src/components/ChicagoArt/Pagination/Pagination.test.tsx
+++ b/src/components/ChicagoArt/Pagination/Pagination.test.tsx
@@ -67,6 +67,38 @@ describe('<Pagination />', () => {
       const { container } = render(<Pagination {...props} />);
       expect(container).toBeEmptyDOMElement();
     });
+
+    it('should render 83 pages when total_pages is 83', () => {
+      const props = initialProps({
+        pagination: {
+          total_pages: 83,
+          total: 4592,
+        },
+        page: 1,
+      });
+
+      render(<Pagination {...props} />);
+      expect(screen.getByText('1')).toHaveAttribute('aria-current', 'page');
+      expect(
+        screen.getByText('Showing 1 of 83 pages (4592 results)')
+      ).toBeInTheDocument();
+    });
+
+    it('should render 83 pages when total_pages is 356', () => {
+      const props = initialProps({
+        pagination: {
+          total_pages: 356,
+          total: 4592,
+        },
+        page: 1,
+      });
+
+      render(<Pagination {...props} />);
+      expect(screen.getByText('1')).toHaveAttribute('aria-current', 'page');
+      expect(
+        screen.getByText('Showing 1 of 83 pages (4592 results)')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('navigation', () => {

--- a/src/components/ChicagoArt/Pagination/Pagination.tsx
+++ b/src/components/ChicagoArt/Pagination/Pagination.tsx
@@ -18,19 +18,22 @@ const Pagination = ({ page, pagination }: PaginationProps) => {
   const searchParams = useSearchParams();
   const router = useRouter();
 
+  // Set a hard limit on pages due to the art API limits
+  const totalPages = pagination.total_pages > 83 ? 83 : pagination.total_pages;
+
   const createPageHandler = useCallback(
     (targetPage: number) => () => {
       const params = new URLSearchParams(searchParams.toString());
       params.set('page', targetPage.toString());
       router.push(`?${params.toString()}`);
     },
-    [page, pagination.total_pages, searchParams, router]
+    [page, totalPages, searchParams, router]
   );
 
   const handlePrevPage = createPageHandler(page - 1);
   const handleNextPage = createPageHandler(page + 1);
   const handleFirstPage = createPageHandler(1);
-  const handleLastPage = createPageHandler(pagination.total_pages);
+  const handleLastPage = createPageHandler(totalPages);
 
   return (
     <nav aria-label="pagination">
@@ -63,25 +66,23 @@ const Pagination = ({ page, pagination }: PaginationProps) => {
           {page}
         </PageButton>
 
-        {page < pagination.total_pages && (
+        {page < totalPages && (
           <PageButton onClick={handleNextPage} key="next-page">
             {page + 1}
           </PageButton>
         )}
 
-        {page < pagination.total_pages - 2 && (
-          <span className={styles.ellipsis}>...</span>
-        )}
+        {page < totalPages - 2 && <span className={styles.ellipsis}>...</span>}
 
-        {page < pagination.total_pages - 1 && (
+        {page < totalPages - 1 && (
           <PageButton onClick={handleLastPage} key="last-page">
-            {pagination.total_pages}
+            {totalPages}
           </PageButton>
         )}
 
         <PageButton
           onClick={handleNextPage}
-          disabled={page === pagination.total_pages}
+          disabled={page === totalPages}
           ariaLabel="Next page"
           isArrow
           key="next-arrow"
@@ -90,8 +91,7 @@ const Pagination = ({ page, pagination }: PaginationProps) => {
         </PageButton>
       </div>
       <div className={styles.paginationInfo}>
-        Showing {page} of {pagination.total_pages} pages ({pagination.total}{' '}
-        results)
+        Showing {page} of {totalPages} pages ({pagination.total} results)
       </div>
     </nav>
   );


### PR DESCRIPTION
**Description**

1. Fixed a bug where when a user clicks the last page, the page errors out. This was due to query limits in the Chicago art API.

**Checklist**

* [ ] `eslint` and `prettier` have been run
* [ ] Tests are included if applicable