### PR TITLE
Add home button to chicago art page

### DIFF
--- a/cypress/e2e/chicagoArt.cy.js
+++ b/cypress/e2e/chicagoArt.cy.js
@@ -3,24 +3,20 @@ describe('Chicago Art', () => {
     cy.visit('/');
   });
 
-  it('should open the Chicago Art page and view a github code sample', () => {
+  it('should open the chicago art page, search for art, click the home button, and return to the portfolio landing page', () => {
     // Open the Chicago Art page
     cy.contains('a', 'Chicago Art Institute Explorer').click();
 
     // Verify the Chicago Art page loads and open the github code example
     cy.contains('h1', 'Chicago Art Institute Explorer').should('be.visible');
 
-    // TODO - Add back github link assertion once refactor of Chicago Art is complete
-    // cy.findByRole('link', {
-    //   name: 'View the code for Chicago Art Institute Explorer on GitHub',
-    // })
-    //   .invoke('removeAttr', 'target')
-    //   .click();
-    // cy.assertGithubCodeExampleLoaded();
-
     // Click input and enter text
     cy.get('input').type('still life');
     cy.get('button').click();
     cy.get('img[alt="A work made of oil on canvas."]').should('be.visible');
+
+    // Click home icon and load portfolio landing page
+    cy.get('[data-testid="home-icon"]').click();
+    cy.contains('h1', 'cal corbin').should('be.visible');
   });
 });

--- a/src/components/ChicagoArt/NavBar/NavBar.module.css
+++ b/src/components/ChicagoArt/NavBar/NavBar.module.css
@@ -17,3 +17,22 @@
         padding: 1rem;
     }
 }
+
+.homeButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.homeIcon {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.5rem;
+    transition: all 0.2s ease;
+}
+
+.homeIcon:hover {
+    color: rgba(255, 117, 140, 0.9);
+    transform: scale(1.1);
+}

--- a/src/components/ChicagoArt/NavBar/NavBar.test.tsx
+++ b/src/components/ChicagoArt/NavBar/NavBar.test.tsx
@@ -2,11 +2,11 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import NavBar from './NavBar';
 
+const mockPush = jest.fn();
 jest.mock('next/navigation', () => {
-  const push = jest.fn();
   return {
     useRouter: () => ({
-      push,
+      mockPush,
       replace: jest.fn(),
       prefetch: jest.fn(),
       back: jest.fn(),
@@ -21,5 +21,13 @@ describe('<NavBar/>', () => {
     render(<NavBar />);
 
     expect(screen.getByTestId('search-form')).toBeInTheDocument();
+  });
+
+  it('should have home link pointing to homepage', () => {
+    render(<NavBar />);
+
+    // Assert that the link has the correct href
+    const homeLink = screen.getByTestId('home-icon').closest('a');
+    expect(homeLink).toHaveAttribute('href', '/');
   });
 });

--- a/src/components/ChicagoArt/NavBar/NavBar.tsx
+++ b/src/components/ChicagoArt/NavBar/NavBar.tsx
@@ -1,9 +1,19 @@
-import SearchBar from '../SearchBar/SearchBar';
 import styles from './NavBar.module.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHome } from '@fortawesome/free-solid-svg-icons';
+import Link from 'next/link';
+import SearchBar from '../SearchBar/SearchBar';
 
 const NavBar = () => {
   return (
     <nav className={styles.navbar}>
+      <Link href="/" className={styles.homeButton}>
+        <FontAwesomeIcon
+          icon={faHome}
+          className={styles.homeIcon}
+          data-testid="home-icon"
+        />
+      </Link>
       <SearchBar />
     </nav>
   );


### PR DESCRIPTION
**Description**

This PR adds a home button to the chicago art search results page.

**Screen captures**

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/fa66ba50-b15d-449a-baa4-c8691c7ea028" />

**Checklist**

* [x] `eslint` and `prettier` have been run
* [x] Tests are included if applicable